### PR TITLE
Update Honda Insight generations: Add Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Honda Insight
 
+This repository contains signal set configurations for the Honda Insight, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Honda Insight.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Honda_Insight"
+
 generations:
   - name: "First Generation"
     start_year: 1999


### PR DESCRIPTION
- Added Wikipedia reference URL to generations.yaml
- Updated README.md with standard template containing proper vehicle name and description

Changes were verified against Honda Insight Wikipedia article confirming:
- Three distinct generations (1999-2006, 2009-2014, 2018-2022)
- Correct body styles and powertrain information
- Accurate production and model year ranges

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
